### PR TITLE
封装 response 全局设置

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -5,7 +5,8 @@
 import json
 import time
 
-from flask import Flask, request, g
+from app.libs.LinFlask import LinFlask
+from flask import request, g
 from flask_cors import CORS
 from lin import Lin
 
@@ -63,7 +64,7 @@ def register_after_request(app):
 
 
 def create_app(register_all=True, environment='production'):
-    app = Flask(__name__, static_folder='./assets')
+    app = LinFlask(__name__, static_folder='./assets')
     app.config['ENV'] = environment
     env = app.config.get('ENV')
     if env == 'production':

--- a/app/libs/lin_flask.py
+++ b/app/libs/lin_flask.py
@@ -1,0 +1,24 @@
+from flask.app import Flask, jsonify
+from app.libs.lin_response import LinResponse
+
+
+class LinFlask(Flask):
+    response_class = LinResponse
+
+    def make_response(self, rv, types: iter = (list, set)):
+        """
+        基本用途为将视图函数返回的值转换为flask内置支持的类型
+        string, dict, tuple, Response instance, or WSGI callable
+        例如：默认将 list 和 set 类型直接转换为json类型返回，
+        这样就不需要在每个视图函数返回的时候都调用 jsonify
+        代码更加简洁
+
+        如果需要对视图函数返回的值进行统一的处理和封装，也可以在此函数下进行
+
+        :param rv: response value
+        :param types: types to change
+        :return:
+        """
+        if isinstance(rv, types):
+            rv = jsonify(rv)
+        return super(LinFlask, self).make_response(rv)

--- a/app/libs/lin_response.py
+++ b/app/libs/lin_response.py
@@ -1,0 +1,18 @@
+from flask.app import Response, jsonify
+
+
+class LinResponse(Response):
+    # default_mimetype = 'application/json'   # 设置默认 response 类型，默认是 text/html
+
+    @classmethod
+    def force_type(cls, rv, environ=None):
+        """
+        只有当视图函数返回 WSGI callable 或者其它可调用对象时，才会调用 force_type
+        具体参见 flask/app.py 中 make_response 源码部分
+        :param rv: response value, a response object or wsgi application.
+        :param environ: a WSGI environment object.
+        :return: a response object.
+        """
+        if isinstance(rv, (dict, list, tuple, set)):
+            rv = jsonify(rv)
+        return super(LinResponse, cls).force_type(rv, environ)


### PR DESCRIPTION
每个视图函数都要调用一次 `jsonify` 非常不方便，所以封装了一个全局 `response` 响应统一处理返回的值。
当前是增加了返回 `list` 和 `set` 类型时默认转换为 `json` 类型。
用户可以自定义全局 `response` ，并且通过 `environ` 信息可以做到分视图甚至更精细的各种控制方式

以下是 `environ` 信息，好心的我手动回车了 ： ）
```
<class 'dict'>: 
{
'wsgi.version': (1, 0), 
'wsgi.url_scheme': 'http', 
'wsgi.input': <_io.BufferedReader name=2068>, 
'wsgi.errors': <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>, 
'wsgi.multithread': True, 
'wsgi.multiprocess': False, 
'wsgi.run_once': False, 
'werkzeug.server.shutdown': <function WSGIRequestHandler.make_environ.<locals>.shutdown_server at 0x000002BDDA692D08>, 
'SERVER_SOFTWARE': 'Werkzeug/0.15.5', 
'REQUEST_METHOD': 'GET', 
'SCRIPT_NAME': '', 
'PATH_INFO': '/v1/contest/', 
'QUERY_STRING': 'page=0&count=3', 
'REQUEST_URI': '/v1/contest/?page=0&count=3', 
'RAW_URI': '/v1/contest/?page=0&count=3', 
'REMOTE_ADDR': '127.0.0.1', 
'REMOTE_PORT': 57106, 
'SERVER_NAME': '127.0.0.1', 
'SERVER_PORT': '5000', 
'SERVER_PROTOCOL': 'HTTP/1.1', 
'HTTP_AUTHORIZATION': 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1NjQxNTc2NzMsIm5iZiI6MTU2NDE1NzY3MywianRpIjoiMmVhMTkyZGUtOGZiMS00NGYzLTgxMDQtZGZiNDcyNDQyMWQ0IiwiZXhwIjoxNTY0MTYxMjczLCJpZGVudGl0eSI6eyJ1aWQiOjEsInNjb3BlIjoibGluIn0sImZyZXNoIjpmYWxzZSwidHlwZSI6ImFjY2VzcyIsInVzZXJfY2xhaW1zIjp7InVpZCI6MSwic2NvcGUiOiJsaW4iLCJyZW1vdGVfYWRkciI6bnVsbH19.wGrIetuwzCU4R7nvkw6eG9GgHc3P2gTNGA5v5d3NnJs', 
'HTTP_USER_AGENT': 'PostmanRuntime/7.15.2', 
'HTTP_ACCEPT': '*/*', 
'HTTP_CACHE_CONTROL': 'no-cache', 
'HTTP_POSTMAN_TOKEN': 'd88e82cc-fd30-4e90-ab42-cba84be1e309', 
'HTTP_HOST': 'localhost:5000', 
'HTTP_ACCEPT_ENCODING': 'gzip, deflate', 
'HTTP_CONNECTION': 'keep-alive', 
'werkzeug.request': <Request 'http://localhost:5000/v1/contest/?page=0&count=3' [GET]>
}
```